### PR TITLE
fix: preserve trailing null gates in fixed-width parser

### DIFF
--- a/src/test/fixtures/sample-data.ts
+++ b/src/test/fixtures/sample-data.ts
@@ -33,6 +33,24 @@ export const sampleGatesStrings = {
     // Trimmed fixed-width (server trimmed leading spaces) with empty value at gate 7
     trimmedWithEmpty: '0  0  0  2  2  0     2  0  0  0 50  2  2',
   },
+  // Sparse gates: C123 uses spaces (not zeros) for unscored gates in Result Type="T"
+  // With server fix (trimValues: false), these arrive UNTRIMMED to the client
+  sparse: {
+    // All gates unscored (72 chars = 24 gates × 3 chars, all spaces)
+    allEmpty24: ' '.repeat(72),
+    // All gates unscored (90 chars = 30 gates × 3 chars, all spaces)
+    allEmpty30: ' '.repeat(90),
+    // Only gate 5 scored as touch (2), rest unscored, 24-gate course
+    gate5touch24: '   '.repeat(4) + '  2' + '   '.repeat(19),
+    // Only gate 5 scored as touch, 30-gate course (90 chars)
+    gate5touch30: '   '.repeat(4) + '  2' + '   '.repeat(25),
+    // Gate 1 and gate 5 both scored
+    gate1and5: '  2' + '   '.repeat(3) + '  2' + '   '.repeat(19),
+    // Gate 1 scored, rest unscored (24 gates)
+    gate1only: '  2' + '   '.repeat(23),
+    // Multiple scattered: gate 3=2, gate 10=50, gate 20=2
+    scattered24: '   '.repeat(2) + '  2' + '   '.repeat(6) + ' 50' + '   '.repeat(9) + '  2' + '   '.repeat(4),
+  },
 }
 
 export const sampleOnCourseCompetitor = {

--- a/src/utils/gates.test.ts
+++ b/src/utils/gates.test.ts
@@ -72,4 +72,66 @@ describe('gates utilities', () => {
       expect(result[13]).toBe(2)
     })
   })
+
+  describe('sparse gates — untrimmed from server with trimValues: false (issue #2 + c123-server#75)', () => {
+    // C123 uses "   " (3 spaces) for unscored gates — semantically different from "  0" (clean)
+    // With server fix, these strings arrive preserved to the client
+
+    it('parses all-empty 24-gate string as 24 nulls', () => {
+      const result = parseResultsGatesString(sampleGatesStrings.sparse.allEmpty24)
+      expect(result).toHaveLength(24)
+      expect(result.every((v) => v === null)).toBe(true)
+    })
+
+    it('parses all-empty 30-gate string as 30 nulls', () => {
+      const result = parseResultsGatesString(sampleGatesStrings.sparse.allEmpty30)
+      expect(result).toHaveLength(30)
+      expect(result.every((v) => v === null)).toBe(true)
+    })
+
+    it('parses single penalty at gate 5 in 24-gate course', () => {
+      const result = parseResultsGatesString(sampleGatesStrings.sparse.gate5touch24)
+      expect(result).toHaveLength(24)
+      expect(result[0]).toBeNull()
+      expect(result[3]).toBeNull()
+      expect(result[4]).toBe(2)
+      expect(result[5]).toBeNull()
+      expect(result[23]).toBeNull()
+    })
+
+    it('parses single penalty at gate 5 in 30-gate course', () => {
+      const result = parseResultsGatesString(sampleGatesStrings.sparse.gate5touch30)
+      expect(result).toHaveLength(30)
+      expect(result[4]).toBe(2)
+      expect(result[0]).toBeNull()
+      expect(result[29]).toBeNull()
+    })
+
+    it('parses gates 1 and 5 both scored, rest unscored', () => {
+      const result = parseResultsGatesString(sampleGatesStrings.sparse.gate1and5)
+      expect(result).toHaveLength(24)
+      expect(result[0]).toBe(2)
+      expect(result[1]).toBeNull()
+      expect(result[4]).toBe(2)
+      expect(result[23]).toBeNull()
+    })
+
+    it('parses only gate 1 scored in 24-gate course', () => {
+      const result = parseResultsGatesString(sampleGatesStrings.sparse.gate1only)
+      expect(result).toHaveLength(24)
+      expect(result[0]).toBe(2)
+      expect(result[1]).toBeNull()
+      expect(result[23]).toBeNull()
+    })
+
+    it('parses scattered penalties across 24 gates', () => {
+      const result = parseResultsGatesString(sampleGatesStrings.sparse.scattered24)
+      expect(result).toHaveLength(24)
+      expect(result[2]).toBe(2)   // gate 3
+      expect(result[9]).toBe(50)  // gate 10
+      expect(result[19]).toBe(2)  // gate 20
+      expect(result[0]).toBeNull()
+      expect(result[23]).toBeNull()
+    })
+  })
 })

--- a/src/utils/gates.ts
+++ b/src/utils/gates.ts
@@ -53,10 +53,5 @@ function parseFixedWidthGates(gates: string): (number | null)[] {
     }
   }
 
-  // Remove trailing nulls (padding from C123 XML)
-  while (result.length > 0 && result[result.length - 1] === null) {
-    result.pop()
-  }
-
   return result
 }


### PR DESCRIPTION
## Summary

- Remove aggressive trailing null removal from `parseFixedWidthGates()` that was stripping unscored gate positions
- Add tests for sparse gates format (real C123 data where only some gates have been scored)
- Document remaining server-side trimming issue

Closes #2 — partially fixes the bug (untrimmed strings now parse correctly). Full fix requires OpenCanoeTiming/c123-server#75 (server preserving the fixed-width format).

## Root cause

C123 uses `"   "` (3 spaces) for unscored gates in `Result Type="T"` — semantically different from `"  0"` (scored as clean). The parser's `while (result.pop())` loop was removing these trailing nulls, collapsing a 24-element array down to just the elements up to the last penalty.

The grid already limits visible columns via `nrGates` from raceConfig, so extra nulls beyond the course length are harmlessly ignored.

## Remaining issue

When c123-server's `trimValues: true` trims a sparse gates string (e.g. `"              2..."` → `"2"`), positional information is irreversibly lost. This requires a server-side fix tracked in OpenCanoeTiming/c123-server#75.

## Test plan

- [x] 7 new tests for sparse gates format (untrimmed C123 strings) — all pass
- [x] 3 tests documenting server-trimmed behavior (current limitation)
- [x] All 227 existing tests still pass
- [ ] Manual test with c123-server replay after server fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)