### PR TITLE
chore(deps): bump react-dom from 19.2.5 to 19.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@opencanoetiming/timing-design-system": "^0.9.0",
         "react": "^19.2.0",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3864,24 +3864,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@opencanoetiming/timing-design-system": "^0.9.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
@@ -49,3 +49,4 @@
     "ws": "^8.21.0"
   }
 }
+


### PR DESCRIPTION
## Summary

Bumps `react-dom` from `19.2.5` to `19.2.7` to match the current `react` version already in the repo.

### Context

- PR #88 (Dependabot: react-dom 19.2.5→19.2.6) was closed after `@dependabot recreate` because it still caused a version mismatch — `react` had already been bumped to `19.2.7` by a separate update
- Latest npm versions: both `react` and `react-dom` are at `19.2.7`
- Dependabot is on a monthly schedule with a 7-day cooldown, so no automatic fix was forthcoming
- This manual fix skips the intermediate 19.2.6 version and bumps directly to 19.2.7

### CI failure on #88

```
Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version.
  - react:      19.2.7
  - react-dom:  19.2.6
```

This PR resolves that mismatch.