### PR TITLE
ci: attach built dist bundle as asset to GitHub releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,55 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Runs only when a release was just created (i.e. the release PR was
+  # merged). Builds the production bundle and attaches it as a downloadable
+  # asset to the GitHub Release, so the app can be deployed without a local
+  # build. Source-only releases otherwise ship just GitHub's auto "Source
+  # code" archives.
+  attach-bundle:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: npm run build
+
+      - name: Package dist into zip
+        run: |
+          cd dist
+          zip -r "../c123-penalty-check-${{ needs.release-please.outputs.tag_name }}.zip" .
+
+      - name: Upload bundle to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            "c123-penalty-check-${{ needs.release-please.outputs.tag_name }}.zip" \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
Closes #92

## Co se mění

Přidává job `attach-bundle` do `release-please.yml`. Spustí se **jen když release-please vytvoří release** (`releases_created == true`, tj. po mergi release PR):

1. `npm ci` + `npm run build` (Node 20, stejný GitHub Packages auth jako CI kvůli `@opencanoetiming/timing-design-system`)
2. zabalí `dist/` → `c123-penalty-check-<tag>.zip`
3. `gh release upload` nahraje zip jako asset k releasu

Dosud releasy obsahovaly jen automatické *Source code* archivy GitHubu, žádný zbuilděný artefakt.

## Vynucení releasu

Aby šel mechanismus ověřit hned, squash merge tohoto PR ponese footer `Release-As: 1.4.2` (od v1.4.1 jsou jen `chore(deps)` commity, které samy bump nezpůsobí). Tím release-please otevře release PR pro v1.4.2; po jeho mergi vznikne v1.4.2 a nahraje se k němu zip.

## Test plan

- [x] `npm run build` lokálně OK
- [x] zabalení `dist/` do zipu lokálně OK (13 souborů, `index.html` v rootu)
- [x] YAML struktura odpovídá `ci.yml`
- [ ] Po mergi: release-please otevře release PR v1.4.2
- [ ] Po mergi release PR: vznikne Release v1.4.2 s assetem `c123-penalty-check-v1.4.2.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)