### PR TITLE
ci: grant packages:read to release bundle job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     permissions:
       contents: write
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Follow-up to #93.

## Problém

`attach-bundle` job v release-please.yml selhal na `npm ci` s **403 Forbidden** při stahování `@opencanoetiming/timing-design-system` z GitHub Packages. Job měl `permissions: contents: write`, což přepsalo defaulty a odebralo `packages: read`.

→ Release **v1.4.2 vznikl bez assetu**.

## Fix

Přidává `packages: read` do permissions jobu `attach-bundle`.

Squash merge ponese `Release-As: 1.4.3`, aby se mechanismus ověřil end-to-end (po fixu). v1.4.2 dorovnám assetem ručně.

## Test plan

- [ ] Po mergi release PR v1.4.3: `attach-bundle` projde `npm ci` + build a nahraje `c123-penalty-check-v1.4.3.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)