### PR TITLE
fix: divide REST result times by 1000 (ms), not 100 (cs)

### DIFF
--- a/src/services/resultsApi.test.ts
+++ b/src/services/resultsApi.test.ts
@@ -20,9 +20,9 @@ describe('fetchRaceResults', () => {
           bib: '1',
           startTime: '08:30:00',
           status: '',
-          time: 7899,
-          pen: 2,
-          total: 8099,
+          time: 78990, // milliseconds (C123 XML unit) → 78.99s
+          pen: 2, // seconds
+          total: 80990, // milliseconds → 80.99s
           rank: 1,
           gates: '  0  0  2  0  0  0',
           participant: {

--- a/src/services/resultsApi.ts
+++ b/src/services/resultsApi.ts
@@ -16,9 +16,9 @@ interface RestResultRow {
   bib: string
   startTime?: string
   status?: string
-  time?: number // centiseconds
+  time?: number // milliseconds (raw C123 XML unit, e.g. 76990 = 76.99s)
   pen?: number // seconds
-  total?: number // centiseconds
+  total?: number // milliseconds
   rank?: number
   gates?: string // space-separated per-gate penalties
   participant?: {
@@ -37,12 +37,16 @@ interface RestResultsResponse {
 }
 
 /**
- * Convert centiseconds to formatted seconds string.
- * 7899 → "78.99", undefined → ""
+ * Convert milliseconds to a formatted seconds string.
+ * 78990 → "78.99", undefined → ""
+ *
+ * The c123-server REST API returns time/total in milliseconds (the raw C123
+ * XML unit), despite docs/types historically saying "centiseconds". This
+ * matches c123-scoreboard's `formatRestTime` (see c123ServerApi.ts). See #98.
  */
-function csToSeconds(cs: number | undefined): string {
-  if (cs === undefined || cs === null) return ''
-  return (cs / 100).toFixed(2)
+function msToSeconds(ms: number | undefined): string {
+  if (ms === undefined || ms === null) return ''
+  return (ms / 1000).toFixed(2)
 }
 
 /**
@@ -65,8 +69,8 @@ function transformRow(row: RestResultRow): C123ResultRow {
     startTime: row.startTime ?? '',
     gates: row.gates?.trim() ?? '',
     pen: row.pen ?? 0,
-    time: csToSeconds(row.time),
-    total: csToSeconds(row.total),
+    time: msToSeconds(row.time),
+    total: msToSeconds(row.total),
     behind: '',
     status: row.status || undefined,
   }


### PR DESCRIPTION
Closes #98

## Problém

Dojeté závody přednačtené přes REST zobrazovaly časy **10× větší** (75.02s → 750.20s). Reprodukováno kolegou na nejnovějším c123-serveru.

## Root cause

`src/services/resultsApi.ts` dělil `time`/`total` hodnotou **100** (centisekundy). REST API c123-serveru ale vrací tyhle hodnoty v **milisekundách** (raw C123 XML, `<Time>76990</Time>` = 76.99s; server je předává beze změny přes `Number(r.Time)`). `pen` je v sekundách a byl správně.

`76990 / 100 = 769.90` ❌ → `76990 / 1000 = 76.99` ✓

Dokumentace serveru a komentáře typů tvrdí „centiseconds“ — to je nepřesné vůči reálnému chování. **c123-scoreboard** tuhle past už řeší (`c123ServerApi.ts` → `formatRestTime`, dělí 1000, s poznámkou „types say centiseconds but actual values need /1000“). Tenhle PR srovnává penalty-check se scoreboardem.

Latentní od #61 (REST pre-load); projeví se jen v REST fallbacku, když pro závod nejsou živá WebSocket data. Živý OnCourse/scoreboard jedou přes WS (čas už v sekundách) → nedotčeno.

## Změny
- `resultsApi.ts`: `csToSeconds` (÷100) → `msToSeconds` (÷1000); opraveny zavádějící komentáře jednotek.
- `resultsApi.test.ts`: fixture opravena na realistické milisekundy (dosud kódovala špatný předpoklad — proto chyba prošla).
- **c123-server nemodifikován** (CLAUDE.md).

## Test plan
- [x] `resultsApi.test.ts` — regrese reprodukuje bug (red: `789.90` vs `78.99`) a po fixu zelená
- [x] `npm test` — 250/250 prošlo
- [x] `npm run build` — OK
- [x] `npm run lint` — 0 errors (2 staré nesouvisející warningy)

## Screenshoty
Vynecháno záměrně: jde o opravu hodnot, ne vizuální/layout změnu, a screenshot pipeline jede přes živý replay (WebSocket cesta), kterou tahle chyba netýká. Ověřeno regresním testem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)