### PR TITLE
fix: unify in-app name to C123 Penalty Check

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>C123 Scoring</title>
+    <title>C123 Penalty Check</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { fetchScheduleEnrichment } from './services/scheduleApi'
 import { fetchCourses, type CourseConfig } from './services/coursesApi'
 import { fetchRaceResults } from './services/resultsApi'
 
-const STORAGE_KEY_SELECTED_RACE = 'c123-scoring-selected-race'
+const STORAGE_KEY_SELECTED_RACE = 'c123-penalty-check-selected-race'
 
 // View state types for main content area
 type ViewState =

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export function Header({
   return (
     <DSHeader variant="compact">
       <HeaderBrand>
-        <HeaderTitle>C123-SCORING</HeaderTitle>
+        <HeaderTitle>C123-PENALTY-CHECK</HeaderTitle>
       </HeaderBrand>
 
       <div className={styles.raceSelector}>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -409,14 +409,14 @@ export function Settings({
                   <Input
                     id="client-id"
                     type="text"
-                    value={settings.clientId ?? 'c123-scoring'}
+                    value={settings.clientId ?? 'c123-penalty-check'}
                     onChange={(e) => onSettingsChange({ clientId: e.target.value })}
-                    placeholder="c123-scoring"
+                    placeholder="c123-penalty-check"
                     data-testid="settings-client-id"
                   />
                   <p className="form-hint">
                     Identifier sent to server to distinguish this client from others.
-                    Use unique names like "scoring-1", "scoring-finish", etc.
+                    Use unique names like "penalty-1", "penalty-finish", etc.
                   </p>
                 </div>
               </div>

--- a/src/hooks/useCheckedState.ts
+++ b/src/hooks/useCheckedState.ts
@@ -87,7 +87,7 @@ export function useCheckedState(options: UseCheckedStateOptions = {}): UseChecke
   const {
     raceId = null,
     groupId = null,
-    storageKeyPrefix = 'c123-scoring-checked',
+    storageKeyPrefix = 'c123-penalty-check-checked',
   } = options
 
   // Storage key based on race ID only (group filtering happens in memory)

--- a/src/hooks/useGateGroups.ts
+++ b/src/hooks/useGateGroups.ts
@@ -134,7 +134,7 @@ export function useGateGroups(options: UseGateGroupsOptions = {}): UseGateGroups
   const {
     raceConfig = null,
     raceId = null,
-    storageKeyPrefix = 'c123-scoring-gate-groups',
+    storageKeyPrefix = 'c123-penalty-check-gate-groups',
   } = options
 
   // Storage key based on race ID

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -9,7 +9,7 @@ import type { ResultsSortOption } from '../types/ui'
 import { setApiBaseUrl, wsToHttpUrl } from '../services/serverConfig'
 import { saveToCache } from '../services/discovery-client'
 
-const STORAGE_KEY = 'c123-scoring-settings'
+const STORAGE_KEY = 'c123-penalty-check-settings'
 const DEFAULT_SERVER_URL = 'ws://localhost:27123/ws'
 const MAX_HISTORY_LENGTH = 10
 const SAVE_DEBOUNCE_MS = 300
@@ -32,7 +32,7 @@ export interface Settings {
 const DEFAULT_SETTINGS: Settings = {
   serverUrl: DEFAULT_SERVER_URL,
   serverHistory: [],
-  clientId: 'c123-scoring',
+  clientId: 'c123-penalty-check',
   theme: 'auto',
   sortBy: 'startOrder',
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 /**
- * C123-Scoring Entry Point Styles
+ * C123 Penalty Check Entry Point Styles
  *
  * This file imports app-specific styles.
  * The design system CSS is imported via timing.css in main.tsx.

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,5 +1,5 @@
 /**
- * C123-Scoring Application Styles
+ * C123 Penalty Check Application Styles
  *
  * This file contains global styles and overrides that work alongside
  * the timing-design-system. All styles use DS tokens.

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * E2E Tests for C123 Scoring Application
+ * E2E Tests for C123 Penalty Check Application
  *
  * These tests verify actual application behavior without a real server.
  * They test UI navigation, settings, and basic functionality.
@@ -187,7 +187,7 @@ test.describe('Layout Tests', () => {
     // Footer should exist with version info
     const footer = page.locator('footer');
     await expect(footer).toBeVisible();
-    await expect(footer).toContainText('C123 Scoring');
+    await expect(footer).toContainText('C123 Penalty Check');
   });
 
   test('should be responsive on mobile viewport', async ({ page }) => {

--- a/tests/screenshots-static.spec.ts
+++ b/tests/screenshots-static.spec.ts
@@ -21,10 +21,10 @@ test.describe('Screenshot Tests - Static States', () => {
   // so tests go straight to the main UI instead of the discovering screen
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      const raw = localStorage.getItem('c123-scoring-settings')
+      const raw = localStorage.getItem('c123-penalty-check-settings')
       const settings = raw ? JSON.parse(raw) : {}
       settings.serverUrl = 'ws://127.0.0.1:27123/ws'
-      localStorage.setItem('c123-scoring-settings', JSON.stringify(settings))
+      localStorage.setItem('c123-penalty-check-settings', JSON.stringify(settings))
     })
   })
 

--- a/tests/screenshots-with-data.spec.ts
+++ b/tests/screenshots-with-data.spec.ts
@@ -155,12 +155,12 @@ test.describe('Screenshot Tests - With Data', () => {
   // Helper to skip discovery and connect directly
   async function setupDirectConnection(page: Page) {
     await page.addInitScript(() => {
-      const raw = localStorage.getItem('c123-scoring-settings')
+      const raw = localStorage.getItem('c123-penalty-check-settings')
       const settings = raw ? JSON.parse(raw) : {}
       settings.serverUrl = 'ws://127.0.0.1:27123/ws'
-      localStorage.setItem('c123-scoring-settings', JSON.stringify(settings))
+      localStorage.setItem('c123-penalty-check-settings', JSON.stringify(settings))
       // Clear selected race to test auto-selection
-      localStorage.removeItem('c123-scoring-selected-race')
+      localStorage.removeItem('c123-penalty-check-selected-race')
     })
   }
 


### PR DESCRIPTION
Closes #101

## Problém
Hlavička aplikace zobrazovala `C123-SCORING`, zatímco repo, README, package i footer používají **C123 Penalty Check**. Nekonzistentní pojmenování.

## Změny
- **Viditelné UI:** header → `C123-PENALTY-CHECK`, `<title>` záložky → `C123 Penalty Check`, komentáře v CSS.
- **clientId default:** `c123-scoring` → `c123-penalty-check` (hodnota, placeholder i příklady v Settings).
- **localStorage klíče:** `c123-scoring*` → `c123-penalty-check*` (`-settings`, `-selected-race`, `-gate-groups-*`, `-checked-*`).
  - **Bez migrace** (záměrně, dle zadání) — pár nastavení se na nové akci stejně nastaví znovu, takže reset na existujících tabletech je v pohodě.
- Oprava zastaralého e2e assertu (footer čekal „C123 Scoring", reálně je „C123 Penalty Check").

## Mimo rozsah
- Hardcoded `v1.1.0` ve footeru (samostatná věc, existuje `APP_VERSION`).

## Test plan
- [x] `npm test` — 250/250
- [x] `npm run build` — OK
- [x] `npm run lint` — 0 errors (2 staré nesouvisející warningy)
- [x] Ověřeno, že nezůstaly žádné výskyty `c123-scoring`/`C123-SCORING`/`C123 Scoring`
- Screenshoty: CI „e2e" job zachytává statické screenshoty jako artefakt (žádné baseline porovnání). Lokální `take-screenshots.sh` v tomto prostředí nejde (chybí nahrávka + playwright browsery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)