### PR TITLE
fix: preserve TLS when deriving REST URLs from WebSocket URL

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -351,7 +351,9 @@ export function Settings({
                   </div>
                   {urlError && <p className="form-error">{urlError}</p>}
                   <p className="form-hint">
-                    Enter host:port (e.g. 192.168.1.50) or full ws:// URL.
+                    Enter host:port (e.g. 192.168.1.50) or a full ws:// URL.
+                    Behind a TLS reverse proxy use <code>wss://</code> — REST calls
+                    then follow over HTTPS.
                     Use <code>?server=host:port</code> URL param for quick override.
                   </p>
                 </div>

--- a/src/services/discovery-client.test.ts
+++ b/src/services/discovery-client.test.ts
@@ -75,8 +75,18 @@ describe('discovery-client', () => {
       expect(wsToHttpUrl('ws://192.168.1.50:27123/ws')).toBe('http://192.168.1.50:27123')
     })
 
-    it('converts wss:// to http://', () => {
-      expect(wsToHttpUrl('wss://server.example.com:443/ws')).toBe('http://server.example.com:443')
+    it('converts wss:// to https://', () => {
+      expect(wsToHttpUrl('wss://server.example.com:443/ws')).toBe('https://server.example.com:443')
+    })
+
+    it('keeps TLS for a proxied server on the default port', () => {
+      expect(wsToHttpUrl('wss://c123-server.timing/ws')).toBe('https://c123-server.timing')
+    })
+
+    it('strips query parameters from a wss:// URL', () => {
+      expect(wsToHttpUrl('wss://c123-server.timing/ws?clientId=test')).toBe(
+        'https://c123-server.timing'
+      )
     })
 
     it('strips query parameters from /ws path', () => {
@@ -136,6 +146,57 @@ describe('discovery-client', () => {
     it('returns http:// cache entry as-is', () => {
       localStorage.setItem(STORAGE_KEY, 'http://192.168.1.50:27123')
       expect(getApiBaseUrl()).toBe('http://192.168.1.50:27123')
+    })
+
+    it('converts legacy wss:// cache entry to https://', () => {
+      localStorage.setItem(STORAGE_KEY, 'wss://c123-server.timing/ws')
+      expect(getApiBaseUrl()).toBe('https://c123-server.timing')
+    })
+  })
+
+  describe('page protocol handling', () => {
+    const originalLocation = window.location
+
+    function stubLocation(href: string): void {
+      Object.defineProperty(window, 'location', {
+        value: new URL(href),
+        writable: true,
+        configurable: true,
+      })
+    }
+
+    beforeEach(() => {
+      setApiBaseUrl(null)
+      localStorage.clear()
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      })
+      localStorage.clear()
+    })
+
+    it('falls back to the page origin when the app is served over HTTPS', () => {
+      stubLocation('https://c123-server.timing/penalty-check/')
+      expect(getApiBaseUrl()).toBe('https://c123-server.timing')
+    })
+
+    it('falls back to hostname:27123 when the app is served over HTTP', () => {
+      stubLocation('http://192.168.1.50:8080/')
+      expect(getApiBaseUrl()).toBe('http://192.168.1.50:27123')
+    })
+
+    it('normalizes a bare host to https:// on an HTTPS page', () => {
+      stubLocation('https://c123-server.timing/')
+      expect(normalizeServerUrl('other-server.timing')).toBe('https://other-server.timing:27123')
+    })
+
+    it('normalizes a bare host to http:// on an HTTP page', () => {
+      stubLocation('http://192.168.1.50:8080/')
+      expect(normalizeServerUrl('192.168.1.60')).toBe('http://192.168.1.60:27123')
     })
   })
 })

--- a/src/services/discovery-client.test.ts
+++ b/src/services/discovery-client.test.ts
@@ -46,6 +46,10 @@ describe('discovery-client', () => {
     it('uses custom default port', () => {
       expect(normalizeServerUrl('192.168.1.50', 9999)).toBe('http://192.168.1.50:9999')
     })
+
+    it('does not append the default port to an https URL', () => {
+      expect(normalizeServerUrl('https://server.example.com')).toBe('https://server.example.com')
+    })
   })
 
   describe('getWebSocketUrl', () => {
@@ -87,6 +91,18 @@ describe('discovery-client', () => {
       expect(wsToHttpUrl('wss://c123-server.timing/ws?clientId=test')).toBe(
         'https://c123-server.timing'
       )
+    })
+
+    it('strips a trailing slash after /ws', () => {
+      expect(wsToHttpUrl('wss://c123-server.timing/ws/')).toBe('https://c123-server.timing')
+    })
+
+    it('strips a fragment after /ws', () => {
+      expect(wsToHttpUrl('wss://c123-server.timing/ws#section')).toBe('https://c123-server.timing')
+    })
+
+    it('preserves a subpath before /ws', () => {
+      expect(wsToHttpUrl('wss://c123-server.timing/c123/ws')).toBe('https://c123-server.timing/c123')
     })
 
     it('strips query parameters from /ws path', () => {
@@ -189,9 +205,16 @@ describe('discovery-client', () => {
       expect(getApiBaseUrl()).toBe('http://192.168.1.50:27123')
     })
 
-    it('normalizes a bare host to https:// on an HTTPS page', () => {
+    it('normalizes a bare host to https:// without forcing port 27123', () => {
+      // Behind a TLS proxy the server is on the standard HTTPS port, not the
+      // plain-HTTP port it listens on behind the proxy.
       stubLocation('https://c123-server.timing/')
-      expect(normalizeServerUrl('other-server.timing')).toBe('https://other-server.timing:27123')
+      expect(normalizeServerUrl('other-server.timing')).toBe('https://other-server.timing')
+    })
+
+    it('keeps an explicit port on an HTTPS page', () => {
+      stubLocation('https://c123-server.timing/')
+      expect(normalizeServerUrl('other-server.timing:8443')).toBe('https://other-server.timing:8443')
     })
 
     it('normalizes a bare host to http:// on an HTTP page', () => {

--- a/src/services/discovery-client.test.ts
+++ b/src/services/discovery-client.test.ts
@@ -217,6 +217,12 @@ describe('discovery-client', () => {
       expect(normalizeServerUrl('other-server.timing:8443')).toBe('https://other-server.timing:8443')
     })
 
+    it('ignores the defaultPort argument on an HTTPS page', () => {
+      // The TLS proxy owns the port; only a port the user typed is honoured.
+      stubLocation('https://c123-server.timing/')
+      expect(normalizeServerUrl('other-server.timing', 9999)).toBe('https://other-server.timing')
+    })
+
     it('normalizes a bare host to http:// on an HTTP page', () => {
       stubLocation('http://192.168.1.50:8080/')
       expect(normalizeServerUrl('192.168.1.60')).toBe('http://192.168.1.60:27123')

--- a/src/services/discovery-client.ts
+++ b/src/services/discovery-client.ts
@@ -385,13 +385,15 @@ export function normalizeServerUrl(
     url = `${protocol}${url}`
   }
 
-  // Add port if missing
+  // Add port if missing. Not for https: the server itself speaks plain HTTP,
+  // so https means a TLS reverse proxy in front of it, and that listens on the
+  // standard port -- appending 27123 would point past the proxy.
   const protocolEnd = url.indexOf('//') + 2
   const pathStart = url.indexOf('/', protocolEnd)
   const hostPart =
     pathStart === -1 ? url.slice(protocolEnd) : url.slice(protocolEnd, pathStart)
 
-  if (!hostPart.includes(':')) {
+  if (!url.startsWith('https://') && !hostPart.includes(':')) {
     if (pathStart === -1) {
       url = `${url}:${defaultPort}`
     } else {

--- a/src/services/discovery-client.ts
+++ b/src/services/discovery-client.ts
@@ -365,7 +365,8 @@ export async function getServerInfo(
  * Normalize server URL (add protocol and port if missing).
  *
  * @param input - User input (e.g., "192.168.1.50", "server.local:8080")
- * @param defaultPort - Port to use if not specified
+ * @param defaultPort - Port to use if not specified. Ignored when the resolved
+ *   scheme is https, where the TLS proxy owns the port (see below).
  * @returns Normalized URL (e.g., "http://192.168.1.50:27123")
  */
 export function normalizeServerUrl(

--- a/src/services/discovery-client.ts
+++ b/src/services/discovery-client.ts
@@ -374,9 +374,15 @@ export function normalizeServerUrl(
 ): string {
   let url = input.trim()
 
-  // Add protocol if missing
+  // Add protocol if missing. Follow the page protocol: a bare host typed into
+  // settings on an HTTPS page must not downgrade to http:// and get blocked as
+  // mixed content.
   if (!url.startsWith('http://') && !url.startsWith('https://')) {
-    url = `http://${url}`
+    const protocol =
+      typeof window !== 'undefined' && window.location.protocol === 'https:'
+        ? 'https://'
+        : 'http://'
+    url = `${protocol}${url}`
   }
 
   // Add port if missing

--- a/src/services/serverConfig.ts
+++ b/src/services/serverConfig.ts
@@ -17,7 +17,7 @@ export function wsToHttpUrl(wsUrl: string): string {
   return wsUrl
     .replace(/^wss:\/\//, 'https://')
     .replace(/^ws:\/\//, 'http://')
-    .replace(/\/ws(\?.*)?$/, '')
+    .replace(/\/ws\/?(\?[^#]*)?(#.*)?$/, '')
 }
 
 let _baseUrl: string | null = null

--- a/src/services/serverConfig.ts
+++ b/src/services/serverConfig.ts
@@ -9,11 +9,15 @@
 import { STORAGE_KEY } from './discovery-client'
 
 /**
- * Derive HTTP base URL from a WebSocket URL.
- * "ws://host:port/ws" → "http://host:port"
+ * Derive HTTP base URL from a WebSocket URL, preserving TLS.
+ * "ws://host:port/ws"  → "http://host:port"
+ * "wss://host:port/ws" → "https://host:port"
  */
 export function wsToHttpUrl(wsUrl: string): string {
-  return wsUrl.replace(/^wss?:\/\//, 'http://').replace(/\/ws(\?.*)?$/, '')
+  return wsUrl
+    .replace(/^wss:\/\//, 'https://')
+    .replace(/^ws:\/\//, 'http://')
+    .replace(/\/ws(\?.*)?$/, '')
 }
 
 let _baseUrl: string | null = null
@@ -32,7 +36,7 @@ export function setApiBaseUrl(url: string | null): void {
  * Priority:
  * 1. Runtime value (set by discovery or settings change)
  * 2. Discovery cache in localStorage
- * 3. Fallback: same hostname, port 27123
+ * 3. Fallback: derived from the page location (see below)
  */
 export function getApiBaseUrl(): string {
   if (_baseUrl) return _baseUrl
@@ -43,6 +47,14 @@ export function getApiBaseUrl(): string {
     if (cached) return cached.startsWith('ws') ? wsToHttpUrl(cached) : cached
   } catch {
     // localStorage unavailable
+  }
+
+  // Served over HTTPS means a TLS reverse proxy in front of the server, which
+  // normally exposes it on the same origin as the app. Forcing port 27123 here
+  // would point past the proxy at the plain HTTP port and be blocked as mixed
+  // content, so keep the origin as-is.
+  if (window.location.protocol === 'https:') {
+    return window.location.origin
   }
 
   return `http://${window.location.hostname}:27123`


### PR DESCRIPTION
## Problem

Reported by @kubikaugustyn in #115. Setup: c123-server behind NGINX terminating TLS on a local domain, LAN clients with the private CA installed. Setting the WebSocket URL to `wss://c123-server.timing/ws` connected the socket fine, but every REST call went to `http://c123-server.timing` and was blocked as mixed content.

Root cause, `src/services/serverConfig.ts`:

```ts
return wsUrl.replace(/^wss?:\/\//, 'http://').replace(/\/ws(\?.*)?$/, '')
```

`wss://` and `ws://` both mapped to `http://`.

## Changes

| File | Change |
|------|--------|
| `serverConfig.ts` `wsToHttpUrl` | `wss://` → `https://`, `ws://` → `http://`; also strip a trailing slash and fragment after `/ws` |
| `serverConfig.ts` `getApiBaseUrl` | fallback returns `window.location.origin` when the page is HTTPS, instead of `http://<hostname>:27123` |
| `discovery-client.ts` `normalizeServerUrl` | a bare host follows the page protocol; the default port is no longer appended when the scheme is https |
| `Settings.tsx` | hint mentions `wss://` |

The reasoning behind not forcing port 27123 under https: the server itself only speaks plain HTTP, so https always means a reverse proxy in front of it, and the proxy listens on the standard port. Appending 27123 would point past it.

## Test plan

- `npm test` — **262 passed** (12 files), up from 257; `npx tsc --noEmit` and `npx eslint src` clean.
- Test-first: the new assertions were confirmed to fail against the pre-fix code. One pre-existing test, `converts wss:// to http://`, encoded the bug itself and was corrected.
- New coverage: `wss://` → `https://` round trip, proxied host on the default port, query string and fragment stripping, trailing `/ws/`, subpath preservation, legacy `wss://` cache migration, and the page-protocol behaviour of `getApiBaseUrl` / `normalizeServerUrl` under both HTTP and HTTPS.
- Manual verification of the reporter's path is not possible here (needs a TLS proxy), but the chain `Settings → useSettings → wsToHttpUrl → setApiBaseUrl → the four REST clients` was traced end to end and no `http://` remains in it.

## Reviewed

An independent review pass over the first commit found two real defects, both fixed in `e433bdc`:

1. `normalizeServerUrl` still appended `:27123` on an HTTPS page, so a bare host became `https://host:27123` — the very mistake the `getApiBaseUrl` change was made to avoid. A test had pinned that wrong behaviour; it now asserts the port stays implicit.
2. `wss://host/ws/` (trailing slash) passes settings validation and connects, but left `/ws/` in the REST base, producing `https://host/ws//api/...` → 404.

It also confirmed no regression on the plain-HTTP LAN path, and that `getWebSocketUrl`'s `replace(/^http/, 'ws')` is correct for https despite looking fragile.

## Known, out of scope

- `probeServer` (`discovery-client.ts:264`) hardcodes `http://${ip}:${port}`, so the "Scan network" button cannot find a TLS-fronted server and a first run from an HTTPS page burns the 10s discovery timeout on blocked probes. Discovery is skipped whenever a custom URL is configured, so it does not affect the reporter.
- The `getApiBaseUrl` HTTPS fallback is nearly unreachable in practice — `App.tsx` sets the base URL on mount in both discovery branches. It is still the correct value to fall back to.
- On an HTTPS page a bare LAN IP now normalizes to `https://192.168.1.50` (previously `http://192.168.1.50:27123`). That combination — HTTPS page, plain-HTTP server — never worked anyway, since `ws://` is hard-blocked from a secure context; but the port now disappears from the URL with no diagnostic. A Settings-level warning would be the right place to fix that, not `normalizeServerUrl`.
- c123-scoreboard has the same class of bug per the reporter; separate repo, not touched here.

Closes #115
